### PR TITLE
Fixed data type conversion Issues: Long ->long

### DIFF
--- a/x7-repository/src/main/java/x7/repository/dao/DaoImpl.java
+++ b/x7-repository/src/main/java/x7/repository/dao/DaoImpl.java
@@ -227,7 +227,10 @@ public class DaoImpl implements Dao {
             if (keyOneType == String.class) {
                 keyOneValue = 1L;
             }else{
-                keyOneValue = keyOneField.getLong(obj);
+                Object keyValue = keyOneField.get(obj);
+                if (keyValue != null) {
+                    keyOneValue = Long.valueOf(keyValue.toString());
+                }
             }
 
             /*


### PR DESCRIPTION
Fix Issues: Attempt to get java.lang.Long field "xx" with illegal data type conversion to long